### PR TITLE
Fix compilation error on macOS with OCaml >= 4.14.1

### DIFF
--- a/core_thread/src/pthread_np_stubs.c
+++ b/core_thread/src/pthread_np_stubs.c
@@ -66,4 +66,9 @@ CAMLprim value pthread_np_getaffinity_self()
   }
   CAMLreturn(v_cpus);
 }
+
+#else
+
+void avoid_empty_translation_unit_compilation_error_in_core_unix_core_thread(void) {}
+
 #endif /* JSC_PTHREAD_NP */

--- a/linux_ext/src/linux_ext_stubs.c
+++ b/linux_ext/src/linux_ext_stubs.c
@@ -804,6 +804,6 @@ CAMLprim value core_linux_setxattr(value v_path, value v_name, value v_value, va
 
 #else
 
-typedef int avoid_empty_translation_unit_compilation_error;
+void avoid_empty_translation_unit_compilation_error_in_core_unix_linux_ext(void) {}
 
 #endif /* JSC_LINUX_EXT */


### PR DESCRIPTION
```
# File "linux_ext/src/dune", line 1, characters 0-234:
# 1 | (library (name linux_ext) (public_name core_unix.linux_ext)
# 2 |  (libraries core_kernel.bounded_int_table core core_thread filename_unix
# 3 |   time_ns_unix)
# 4 |  (c_names linux_ext_stubs) (preprocessor_deps config.h)
# 5 |  (preprocess (pps ppx_jane)))
# (cd _build/default && /Users/mac1000/.opam/5.0.0~alpha1/bin/ocamlopt.opt -w -40 -g -shared -linkall -I linux_ext/src -o linux_ext/src/linux_ext.cmxs linux_ext/src/linux_ext.cmxa)
# ld: archive has no table of contents file 'linux_ext/src/liblinux_ext_stubs.a' for architecture x86_64
# clang: error: linker command failed with exit code 1 (use -v to see invocation)
# File "caml_startup", line 1:
# Error: Error during linking (exit code 1)
```
The issue is that on macOS those two files are compiled empty. Previously on macOS, `ranlib` would only issue a warning:
```
(cd _build/default && /Users/kit_ty_kate/.opam/4.14.0/bin/ocamlmklib.opt -g -o linux_ext/src/linux_ext_stubs linux_ext/src/linux_ext_stubs.o)
warning: /Library/Developer/CommandLineTools/usr/bin/ranlib: archive library: linux_ext/src/liblinux_ext_stubs.a the table of contents is empty (no object file members in the library define global symbols)
warning: /Library/Developer/CommandLineTools/usr/bin/ranlib: archive library: linux_ext/src/liblinux_ext_stubs.a the table of contents is empty (no object file members in the library define global symbols)
(cd _build/default && /Users/kit_ty_kate/.opam/4.14.0/bin/ocamlmklib.opt -g -o core_thread/src/core_thread_stubs core_thread/src/pthread_np_stubs.o)
warning: /Library/Developer/CommandLineTools/usr/bin/ranlib: archive library: core_thread/src/libcore_thread_stubs.a the table of contents is empty (no object file members in the library define global symbols)
warning: /Library/Developer/CommandLineTools/usr/bin/ranlib: archive library: core_thread/src/libcore_thread_stubs.a the table of contents is empty (no object file members in the library define global symbols)
```
however, since https://github.com/ocaml/ocaml/pull/11184, the use of `ranlib` has been removed, but now `ld` triggers an error when encountering such empty C library.