### PR TITLE
Update bigstring_unix_stubs.c

### DIFF
--- a/core_unix.opam
+++ b/core_unix.opam
@@ -1,4 +1,5 @@
 opam-version: "2.0"
+version: "v0.17.0"
 maintainer: "Jane Street developers"
 authors: ["Jane Street Group, LLC"]
 homepage: "https://github.com/janestreet/core_unix"
@@ -10,17 +11,17 @@ build: [
   ["dune" "build" "-p" name "-j" jobs]
 ]
 depends: [
-  "ocaml" {>= "5.1.0"}
-  "core"
-  "core_kernel"
-  "expect_test_helpers_core"
-  "jane-street-headers"
-  "jst-config"
-  "ppx_jane"
-  "ppx_optcomp"
-  "sexplib"
-  "timezone"
-  "uopt"
+  "ocaml"                    {>= "5.1.0"}
+  "core"                     {>= "v0.17" & < "v0.18"}
+  "core_kernel"              {>= "v0.17" & < "v0.18"}
+  "expect_test_helpers_core" {>= "v0.17" & < "v0.18"}
+  "jane-street-headers"      {>= "v0.17" & < "v0.18"}
+  "jst-config"               {>= "v0.17" & < "v0.18"}
+  "ppx_jane"                 {>= "v0.17" & < "v0.18"}
+  "ppx_optcomp"              {>= "v0.17" & < "v0.18"}
+  "sexplib"                  {>= "v0.17" & < "v0.18"}
+  "timezone"                 {>= "v0.17" & < "v0.18"}
+  "uopt"                     {>= "v0.17" & < "v0.18"}
   "base-threads"
   "dune"                     {>= "3.11.0"}
   "spawn"                    {>= "v0.15"}


### PR DESCRIPTION
The definition of msghdr in musl adds pad in the struct. The proposed initialization clean the whole structure (zeroing) without taking care  of how many fields in the struct are.

Hope it works