### PR TITLE
Constify C constructors and flags tables

### DIFF
--- a/core_unix/src/core_unix_stubs.c
+++ b/core_unix/src/core_unix_stubs.c
@@ -1376,7 +1376,7 @@ CAMLprim value core_unix_mcast_set_loop(value v_socket, value v_loop) {
 /* Scheduling */
 
 #if defined(_POSIX_PRIORITY_SCHEDULING) && (_POSIX_PRIORITY_SCHEDULING + 0 > 0)
-static int sched_policy_table[] = {SCHED_FIFO, SCHED_RR, SCHED_OTHER};
+static const int sched_policy_table[] = {SCHED_FIFO, SCHED_RR, SCHED_OTHER};
 
 CAMLprim value core_unix_sched_setscheduler(value v_pid, value v_policy,
                                             value v_priority) {
@@ -1421,7 +1421,7 @@ CAMLprim value core_unix_unsetenv(value var) {
   return Val_unit;
 }
 
-static int mman_mcl_flags_table[] = {MCL_CURRENT, MCL_FUTURE};
+static const int mman_mcl_flags_table[] = {MCL_CURRENT, MCL_FUTURE};
 
 CAMLprim value core_unix_mlockall(value v_flags) {
   CAMLparam1(v_flags);
@@ -1631,7 +1631,7 @@ static value alloc_ifaddrs(struct ifaddrs *ifap, value family_variant) {
 #endif
 
 /* THE ORDERING OF THESE CONSTANTS MUST MATCH core_unix.ml!!! */
-static uint32_t iff_table[] = {
+static const uint32_t iff_table[] = {
     IFF_ALLMULTI, IFF_AUTOMEDIA,  IFF_BROADCAST,   IFF_DEBUG,
     IFF_DYNAMIC,  IFF_LOOPBACK,   IFF_MASTER,      IFF_MULTICAST,
     IFF_NOARP,    IFF_NOTRAILERS, IFF_POINTOPOINT, IFF_PORTSEL,
@@ -1822,7 +1822,7 @@ static value alloc_process_status(int pid, int status) {
   return res;
 }
 
-static int wait_flag_table[] = {WNOHANG, WUNTRACED};
+static const int wait_flag_table[] = {WNOHANG, WUNTRACED};
 CAMLprim value core_unix_wait4(value flags, value pid_req) {
   CAMLparam0();
   CAMLlocal3(v_status, v_rusage, res);

--- a/core_unix/src/core_unix_stubs.c
+++ b/core_unix/src/core_unix_stubs.c
@@ -1333,11 +1333,22 @@ enum option_type {
 #define caml_unix_setsockopt_aux unix_setsockopt_aux
 #endif
 
+/* caml_unix_getsockopt_aux and caml_unix_setsockopt_aux come from C
+   stubs distributed with the OCaml compiler. At the time of writing
+   they live in otherlibs/unix/sockopt_{unix,win32}.c. */
+#if OCAML_VERSION < 50300
 extern value caml_unix_getsockopt_aux(char *name, enum option_type ty,
                                       int level, int option, value v_socket);
 extern value caml_unix_setsockopt_aux(char *name, enum option_type ty,
                                       int level, int option, value v_socket,
                                       value v_status);
+#else
+extern value caml_unix_getsockopt_aux(const char *name, enum option_type ty,
+                                      int level, int option, value v_socket);
+extern value caml_unix_setsockopt_aux(const char *name, enum option_type ty,
+                                      int level, int option, value v_socket,
+                                      value v_status);
+#endif
 
 CAMLprim value core_unix_mcast_get_ttl(value v_socket) {
   return caml_unix_getsockopt_aux("getsockopt", TYPE_INT, IPPROTO_IP,

--- a/linux_ext/src/linux_ext_stubs.c
+++ b/linux_ext/src/linux_ext_stubs.c
@@ -91,8 +91,8 @@ CAMLprim value core_linux_sysinfo(value __unused v_unit) {
 
 /**/
 
-static int linux_tcpopt_bool[] = {TCP_CORK, TCP_QUICKACK};
-static int linux_tcpopt_string[] = {TCP_CONGESTION};
+static const int linux_tcpopt_bool[] = {TCP_CORK, TCP_QUICKACK};
+static const int linux_tcpopt_string[] = {TCP_CONGESTION};
 
 enum option_type {
   TYPE_BOOL = 0,

--- a/linux_ext/src/linux_ext_stubs.c
+++ b/linux_ext/src/linux_ext_stubs.c
@@ -108,14 +108,22 @@ enum option_type {
 #define caml_unix_setsockopt_aux unix_setsockopt_aux
 #endif
 
-/* unix_getsockopt_aux and unix_setsockopt_aux come from C stubs distributed
-   with the OCaml compiler.  At the time of writing they live in
-   otherlibs/unix/sockopt.c. */
+/* caml_unix_getsockopt_aux and caml_unix_setsockopt_aux come from C
+   stubs distributed with the OCaml compiler. At the time of writing
+   they live in otherlibs/unix/sockopt_{unix,win32}.c. */
+#if OCAML_VERSION < 50300
 extern value caml_unix_getsockopt_aux(char *name, enum option_type ty,
                                       int level, int option, value v_socket);
 extern value caml_unix_setsockopt_aux(char *name, enum option_type ty,
                                       int level, int option, value v_socket,
                                       value v_status);
+#else
+extern value caml_unix_getsockopt_aux(const char *name, enum option_type ty,
+                                      int level, int option, value v_socket);
+extern value caml_unix_setsockopt_aux(const char *name, enum option_type ty,
+                                      int level, int option, value v_socket,
+                                      value v_status);
+#endif
 
 CAMLprim value core_linux_gettcpopt_bool_stub(value v_socket, value v_option) {
   int option = linux_tcpopt_bool[Int_val(v_option)];

--- a/syslog/src/syslog_stubs.c
+++ b/syslog/src/syslog_stubs.c
@@ -8,7 +8,7 @@
 
 #include "ocaml_utils.h"
 
-static int log_open_options[] = {
+static const int log_open_options[] = {
   /* THESE MUST STAY IN THE SAME ORDER AS IN syslog.ml!!! */
   LOG_PID, LOG_CONS, LOG_ODELAY, LOG_NDELAY, LOG_NOWAIT, LOG_PERROR
 };
@@ -17,7 +17,7 @@ CAMLprim value core_syslog_open_option_to_int(value v_open_option) {
   return Val_int(log_open_options[Int_val(v_open_option)]);
 }
 
-static int log_facilities[] = {
+static const int log_facilities[] = {
   /* THESE MUST STAY IN THE SAME ORDER AS IN syslog.ml!!! */
   LOG_KERN, LOG_USER, LOG_MAIL, LOG_DAEMON, LOG_AUTH, LOG_SYSLOG, LOG_LPR, LOG_NEWS,
   LOG_UUCP, LOG_CRON, LOG_AUTHPRIV, LOG_FTP,
@@ -35,7 +35,7 @@ CAMLprim value core_syslog_facility_to_int(value v_facility) {
   return Val_int(log_facilities[Int_val(v_facility)]);
 }
 
-static int log_levels[] = {
+static const int log_levels[] = {
   /* THESE MUST STAY IN THE SAME ORDER AS IN syslog.ml!!! */
   LOG_EMERG, LOG_ALERT, LOG_CRIT, LOG_ERR, LOG_WARNING, LOG_NOTICE, LOG_INFO, LOG_DEBUG
 };

--- a/unix_pseudo_terminal/src/unix_pseudo_terminal_stubs.c
+++ b/unix_pseudo_terminal/src/unix_pseudo_terminal_stubs.c
@@ -27,7 +27,7 @@ int posix_openpt(int flags)
 }
 #endif
 
-static int posix_openpt_flag_table[2] = { O_RDWR, O_NOCTTY };
+static const int posix_openpt_flag_table[2] = { O_RDWR, O_NOCTTY };
 
 CAMLprim value unix_posix_openpt(value flags)
 {


### PR DESCRIPTION
There's little value to this considering the constructors tables are static, used very locally, but this serves nonetheless as an indication to the programmer that the tables are not to be modified. Now these tables will go in the readonly segment, where they belong.

Cf https://github.com/ocaml/ocaml/pull/12223, https://github.com/ocaml/ocaml/pull/12951.